### PR TITLE
Allow context in authorize params

### DIFF
--- a/lib/omniauth/strategies/gaggleamp.rb
+++ b/lib/omniauth/strategies/gaggleamp.rb
@@ -40,6 +40,9 @@ module OmniAuth
 
           service = session['omniauth.params'].delete('service') rescue nil
           params[:service] = service if service
+
+          context = session['omniauth.params'].delete('context') rescue nil
+          params[:context] = context if context
         end
       end
     end


### PR DESCRIPTION
This PR allow `context` parameter to be included in the `authorize_params`