### PR TITLE
[GAG-9714] Update omniauth

### DIFF
--- a/lib/omniauth-gaggleamp/version.rb
+++ b/lib/omniauth-gaggleamp/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module GaggleAMP
-    VERSION = "0.1.1"
+    VERSION = "0.1.2"
   end
 end

--- a/omniauth-gaggleamp.gemspec
+++ b/omniauth-gaggleamp.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "omniauth", "~> 1.0"
-  spec.add_runtime_dependency "omniauth-oauth2"
+  spec.add_runtime_dependency "omniauth"
+  spec.add_runtime_dependency "omniauth-oauth2", "~> 1.7.3"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "< 11.0"


### PR DESCRIPTION
This PR updates the `omniauth` and `omniauth-oauth2` dependencies to ensure compatibility with the updates in the Amplify PR.